### PR TITLE
docs: link new guides from README, add copyright footers to new docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ Total: ~1,000 lines. Coffee break reading.
 
 ### Core guides
 
+The progressive tutorial, technical patterns, and deployment paths for using Bedsheet day-to-day. Start here if you're new to the framework.
+
 - **[User Guide](https://sivang.github.io/bedsheet/user-guide.html)** — Beginner to advanced, 12 lessons
 - **[Technical Guide](https://sivang.github.io/bedsheet/technical-guide.html)** — Python patterns explained
 - **[Deployment Guide](https://sivang.github.io/bedsheet/deployment-guide.html)** — Local, GCP, and AWS deployment

--- a/README.md
+++ b/README.md
@@ -380,12 +380,37 @@ Total: ~1,000 lines. Coffee break reading.
 
 ## Documentation
 
+### Core guides
+
 - **[User Guide](https://sivang.github.io/bedsheet/user-guide.html)** — Beginner to advanced, 12 lessons
 - **[Technical Guide](https://sivang.github.io/bedsheet/technical-guide.html)** — Python patterns explained
 - **[Deployment Guide](https://sivang.github.io/bedsheet/deployment-guide.html)** — Local, GCP, and AWS deployment
 - **[GCP Deployment Deep Dive](https://sivang.github.io/bedsheet/gcp-deployment-deep-dive.html)** — GCP architecture, troubleshooting, and best practices
 - **[Multi-Agent Guide](https://sivang.github.io/bedsheet/multi-agent-guide.html)** — Supervisor deep dive
 - **[Multi-Agent Patterns](https://sivang.github.io/bedsheet/multi-agent-patterns.html)** — Swarms, Graphs, Workflows, A2A
+
+### Sixth Sense — distributed agent communication
+
+Agents running on different machines, processes, or networks can exchange typed signals over a pluggable transport. Ships with `MockSenseTransport` for tests and `PubNubTransport` for production; future transports (NATS, Redis pub/sub) plug in via the `make_sense_transport()` factory.
+
+- **[Sixth Sense Guide](https://sivang.github.io/bedsheet/sixth-sense-guide.html)** — Tutorial: join a network, send signals, request/response, claim protocol
+- **[Sixth Sense Design](https://sivang.github.io/bedsheet/sixth-sense-design.html)** — Architecture, protocols, design decisions
+- **[Sixth Sense Internals](https://sivang.github.io/bedsheet/sixth-sense-internals.html)** — Honest deep-dive into how every piece works under the hood
+
+### Agent Sentinel — security demo
+
+A complete multi-agent security monitoring system built on Bedsheet + Sixth Sense. Demonstrates tamper-proof tool execution via a pure-Python Action Gateway, behavior-based and supply-chain sentinels, and a sentinel commander that orchestrates threat response. Ships with a live dashboard.
+
+- **[Agent Sentinel Guide](https://sivang.github.io/bedsheet/agent-sentinel-guide.html)** — What it is, how it works, how to run it
+- **[Agent Sentinel Setup](https://sivang.github.io/bedsheet/agent-sentinel-setup.html)** — Step-by-step setup instructions
+- **[Sentinel Network Guide](https://sivang.github.io/bedsheet/sentinel-network-guide.html)** — Multi-agent network topology and signal flow
+- **[Security Architecture](https://sivang.github.io/bedsheet/agent-sentinel-security-architecture.html)** — Threat model, trust boundaries, and mitigations (including a documented prompt-injection vector and the v0.6 roadmap to close it)
+- **[Live Dashboard](https://sivang.github.io/bedsheet/agent-sentinel-dashboard.html)** — Real-time PubNub signal visualization for the running sentinel network
+
+### Engineering notes & retrospectives
+
+- **[PR #4 Fixes Explained](docs/pr-4-fixes-explained.md)** — Post-merge walkthrough of the nine fixes that landed with the Sixth Sense + Agent Sentinel + Gemini release. Each fix documents the Python language constructs involved (async generators, `asyncio` weak task refs, PEP 563, `importlib.util`, lazy imports, list invariance, etc.) with before/after snippets. Also mirrored on the [wiki](https://github.com/sivang/bedsheet/wiki/PR-4-Fixes-Explained).
+- **[Project Wiki](https://github.com/sivang/bedsheet/wiki)** — Informal notes, post-hoc explanations, and collaborative knowledge that doesn't fit the polished user guide
 
 ---
 

--- a/docs/agent-sentinel-dashboard.html
+++ b/docs/agent-sentinel-dashboard.html
@@ -2174,5 +2174,10 @@
         });
     })();
     </script>
+    <footer style="margin: 24px 16px 12px; padding-top: 16px; border-top: 1px solid rgba(255,255,255,0.08); text-align: center; color: rgba(255,255,255,0.55); font-size: 12px;">
+        <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/" style="color: rgba(255,255,255,0.75);">Vitakka Consulting</a></strong></p>
+        <p style="margin-top: 6px;">Elastic License 2.0</p>
+        <p style="margin-top: 6px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet" style="color: rgba(255,255,255,0.75);">GitHub</a> | <a href="agent-sentinel-guide.html" style="color: rgba(255,255,255,0.75);">Agent Sentinel Guide</a></p>
+    </footer>
 </body>
 </html>

--- a/docs/agent-sentinel-dashboard.html
+++ b/docs/agent-sentinel-dashboard.html
@@ -2174,10 +2174,15 @@
         });
     })();
     </script>
-    <footer style="margin: 24px 16px 12px; padding-top: 16px; border-top: 1px solid rgba(255,255,255,0.08); text-align: center; color: rgba(255,255,255,0.55); font-size: 12px;">
-        <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/" style="color: rgba(255,255,255,0.75);">Vitakka Consulting</a></strong></p>
-        <p style="margin-top: 6px;">Elastic License 2.0</p>
-        <p style="margin-top: 6px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet" style="color: rgba(255,255,255,0.75);">GitHub</a> | <a href="agent-sentinel-guide.html" style="color: rgba(255,255,255,0.75);">Agent Sentinel Guide</a></p>
+    <!--
+        Footer is a fixed-position HUD overlay because the dashboard body uses
+        `overflow: hidden` and `.app` fills the viewport via a locked CSS grid.
+        A regular bottom-of-page footer would be clipped invisible. The overlay
+        sits in the bottom-right corner with a compact one-line layout that
+        matches the dashboard's HUD aesthetic and stays out of the map area.
+    -->
+    <footer style="position: fixed; bottom: 6px; right: 12px; z-index: 100; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: rgba(255,255,255,0.45); text-align: right; pointer-events: auto; line-height: 1.6;">
+        <span>&copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/" style="color: rgba(255,255,255,0.65); text-decoration: none;">Vitakka Consulting</a> &middot; Elastic License 2.0 &middot; <a href="https://github.com/sivang/bedsheet" style="color: rgba(255,255,255,0.65); text-decoration: none;">GitHub</a></span>
     </footer>
 </body>
 </html>

--- a/docs/agent-sentinel-guide.html
+++ b/docs/agent-sentinel-guide.html
@@ -590,7 +590,9 @@ bedsheet generate --target aws      # Amazon Web Services</code></pre>
     </div>
 
     <footer>
-        <p>Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a> | <a href="sixth-sense-guide.html">Sixth Sense Tutorial</a> | <a href="sixth-sense-design.html">Design Document</a></p>
+        <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/">Vitakka Consulting</a></strong></p>
+        <p style="margin-top: 8px;">Elastic License 2.0</p>
+        <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a> | <a href="sixth-sense-guide.html">Sixth Sense Tutorial</a> | <a href="sixth-sense-design.html">Design Document</a></p>
     </footer>
 </main>
 

--- a/docs/agent-sentinel-security-architecture.html
+++ b/docs/agent-sentinel-security-architecture.html
@@ -690,6 +690,12 @@
         </tbody>
     </table>
 
+    <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid #e5e7eb; text-align: center; color: #6b7280;">
+        <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/" style="color: #4b5563;">Vitakka Consulting</a></strong></p>
+        <p style="margin-top: 8px;">Elastic License 2.0</p>
+        <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet" style="color: #4b5563;">GitHub</a> | <a href="agent-sentinel-guide.html" style="color: #4b5563;">Agent Sentinel Guide</a> | <a href="sentinel-network-guide.html" style="color: #4b5563;">Network Guide</a></p>
+    </footer>
+
 </div>
 </body>
 </html>

--- a/docs/agent-sentinel-security-architecture.html
+++ b/docs/agent-sentinel-security-architecture.html
@@ -690,10 +690,10 @@
         </tbody>
     </table>
 
-    <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid #e5e7eb; text-align: center; color: #6b7280;">
-        <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/" style="color: #4b5563;">Vitakka Consulting</a></strong></p>
+    <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--border-dim); text-align: center; color: var(--text-secondary); font-size: 13px; line-height: 1.7;">
+        <p><strong style="color: var(--text-primary);">Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/" style="color: var(--cyan); text-decoration: none;">Vitakka Consulting</a></strong></p>
         <p style="margin-top: 8px;">Elastic License 2.0</p>
-        <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet" style="color: #4b5563;">GitHub</a> | <a href="agent-sentinel-guide.html" style="color: #4b5563;">Agent Sentinel Guide</a> | <a href="sentinel-network-guide.html" style="color: #4b5563;">Network Guide</a></p>
+        <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet" style="color: var(--cyan); text-decoration: none;">GitHub</a> | <a href="agent-sentinel-guide.html" style="color: var(--cyan); text-decoration: none;">Agent Sentinel Guide</a> | <a href="sentinel-network-guide.html" style="color: var(--cyan); text-decoration: none;">Network Guide</a></p>
     </footer>
 
 </div>

--- a/docs/agent-sentinel-setup.html
+++ b/docs/agent-sentinel-setup.html
@@ -680,6 +680,12 @@ bedsheet validate</code></pre>
                 <li>Create new worker agents with different capabilities</li>
             </ul>
         </section>
+
+        <footer>
+            <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/">Vitakka Consulting</a></strong></p>
+            <p style="margin-top: 8px;">Elastic License 2.0</p>
+            <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a> | <a href="agent-sentinel-guide.html">Agent Sentinel Guide</a> | <a href="agent-sentinel-security-architecture.html">Security Architecture</a></p>
+        </footer>
     </main>
 
     <script>hljs.highlightAll();</script>

--- a/docs/pr-4-fixes-explained.md
+++ b/docs/pr-4-fixes-explained.md
@@ -558,3 +558,11 @@ This is exactly what Python's normal import machinery does under the hood; `impo
 ## One-line meta takeaway
 
 The common thread is **honesty about state**: the B1 fix makes streamed text equal persisted text, the B2 fix prevents the event loop from silently dropping work, the B3 fix stops the audit ledger from lying, the H1 fix turns a silent retry loop into an explicit error, and the factory removes hidden coupling between examples and one specific transport. Every fix replaces an implicit behavior with an explicit one.
+
+---
+
+**Copyright © 2025-2026 Sivan Grünberg, [Vitakka Consulting](https://vitakka.co/)**
+
+Elastic License 2.0
+
+Bedsheet Agents — [GitHub](https://github.com/sivang/bedsheet) · [User Guide](https://sivang.github.io/bedsheet/user-guide.html) · [Technical Guide](https://sivang.github.io/bedsheet/technical-guide.html)

--- a/docs/sentinel-network-guide.html
+++ b/docs/sentinel-network-guide.html
@@ -1072,6 +1072,12 @@ python run.py</code></pre>
         </p>
     </section>
 
+    <footer>
+        <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/">Vitakka Consulting</a></strong></p>
+        <p style="margin-top: 8px;">Elastic License 2.0</p>
+        <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a> | <a href="agent-sentinel-guide.html">Agent Sentinel Guide</a> | <a href="sixth-sense-design.html">Sixth Sense Design</a></p>
+    </footer>
+
 </main>
 
 <script>hljs.highlightAll();</script>

--- a/docs/sixth-sense-design.html
+++ b/docs/sixth-sense-design.html
@@ -660,7 +660,9 @@ class MockSenseTransport:
     </ul>
 
     <footer>
-        <p>Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a> | <a href="sixth-sense-guide.html">Sixth Sense Tutorial</a> | <a href="agent-sentinel-guide.html">Agent Sentinel Guide</a></p>
+        <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/">Vitakka Consulting</a></strong></p>
+        <p style="margin-top: 8px;">Elastic License 2.0</p>
+        <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a> | <a href="sixth-sense-guide.html">Sixth Sense Tutorial</a> | <a href="agent-sentinel-guide.html">Agent Sentinel Guide</a></p>
     </footer>
 </main>
 

--- a/docs/sixth-sense-guide.html
+++ b/docs/sixth-sense-guide.html
@@ -497,7 +497,9 @@ assert result == "done"</code></pre>
     </table>
 
     <footer>
-        <p>Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a></p>
+        <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/">Vitakka Consulting</a></strong></p>
+        <p style="margin-top: 8px;">Elastic License 2.0</p>
+        <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a> | <a href="sixth-sense-design.html">Design Document</a> | <a href="sixth-sense-internals.html">Internals</a></p>
     </footer>
 </main>
 

--- a/docs/sixth-sense-internals.html
+++ b/docs/sixth-sense-internals.html
@@ -574,6 +574,12 @@ transport_b = transport_a.create_peer()  # creates a new MockSenseTransport(hub)
     </tbody>
   </table>
 
+  <footer>
+    <p><strong>Copyright &copy; 2025-2026 Sivan Grünberg, <a href="https://vitakka.co/">Vitakka Consulting</a></strong></p>
+    <p style="margin-top: 8px;">Elastic License 2.0</p>
+    <p style="margin-top: 8px;">Bedsheet Agents &mdash; <a href="https://github.com/sivang/bedsheet">GitHub</a> | <a href="sixth-sense-guide.html">Sixth Sense Tutorial</a> | <a href="sixth-sense-design.html">Design Document</a></p>
+  </footer>
+
 </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary

PR #4 landed eight new HTML docs + one new markdown doc, but:

1. **None were linked from README.md** — a reader landing on the repo had no way to discover the Sixth Sense guides, Agent Sentinel demo, Security Architecture doc, or the live dashboard
2. **None carried the project's copyright footer** — the canonical `Copyright © 2025-2026 Sivan Grünberg, Vitakka Consulting / Elastic License 2.0` footer from `docs/user-guide.html` was missing everywhere

This PR fixes both.

## README restructure

The Documentation section now has four groups with one-paragraph intros:

- **Core guides** (unchanged — user guide, technical, deployment, multi-agent)
- **Sixth Sense** — distributed agent communication (guide, design, internals)
- **Agent Sentinel** — security demo (guide, setup, network, security architecture, live dashboard)
- **Engineering notes & retrospectives** — PR #4 fixes walkthrough + wiki link

Each group's intro explains what the feature is so readers have enough context before clicking through.

## Copyright footers

Added the footer pattern from `docs/user-guide.html:1331-1338` to all eight new HTML docs:

```
Copyright © 2025-2026 Sivan Grünberg, Vitakka Consulting
Elastic License 2.0
Bedsheet Agents — GitHub | <page-specific nav>
```

- 3 files had a thin `<footer>` with just a GitHub link → prepended copyright lines
- 3 files had `</main>` but no footer → inserted full footer before `</main>`
- 2 files had only `</body>` (agent-sentinel-dashboard and agent-sentinel-security-architecture) → inserted footer before `</body>` with inline styles matching their visual context (the dashboard uses a dark theme)

`docs/pr-4-fixes-explained.md` got a markdown-formatted equivalent with the same copyright + license + nav links.

## Test plan

- [x] `README.md` renders correctly on GitHub (headings, links, nested sections)
- [x] All new HTML doc links in README resolve to files that exist in `docs/`
- [x] All eight modified HTML files still have valid HTML structure (footer inserted in correct position relative to `</main>` / `</body>`)
- [x] Dashboard footer uses dark-theme-compatible inline styles (matches the page's existing visual language)
- [x] Markdown footer on `pr-4-fixes-explained.md` renders as a standard GitHub-flavored markdown footer
- [x] No code changes, so CI jobs (lint/typecheck/test) run against an unchanged code surface

## Files changed

- `README.md` — restructured Documentation section
- `docs/agent-sentinel-guide.html` — footer copyright
- `docs/agent-sentinel-setup.html` — footer inserted
- `docs/agent-sentinel-dashboard.html` — footer inserted (dark theme)
- `docs/agent-sentinel-security-architecture.html` — footer inserted
- `docs/sentinel-network-guide.html` — footer inserted
- `docs/sixth-sense-design.html` — footer copyright
- `docs/sixth-sense-guide.html` — footer copyright
- `docs/sixth-sense-internals.html` — footer inserted
- `docs/pr-4-fixes-explained.md` — markdown footer
