### PR TITLE
fix: Supervisor replay guards + PubNub error logging

### DIFF
--- a/bedsheet/supervisor.py
+++ b/bedsheet/supervisor.py
@@ -196,6 +196,17 @@ If no agent is appropriate, respond directly.
                 tools=tools,
             )
 
+            if response.stop_reason == "replay_exhausted":
+                yield CompletionEvent(response="[Replay ended — recording exhausted]")
+                return
+
+            if not response.text and not response.tool_calls:
+                yield ErrorEvent(
+                    error="Model returned an empty response (no text, no tool calls)",
+                    recoverable=False,
+                )
+                return
+
             if response.text and not response.tool_calls:
                 assistant_message = Message(role="assistant", content=response.text)
                 messages.append(assistant_message)

--- a/examples/agent-sentinel/agents/behavior_sentinel.py
+++ b/examples/agent-sentinel/agents/behavior_sentinel.py
@@ -8,6 +8,7 @@ gateway that actually enforced the rules — it cannot be tampered with.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 
 from bedsheet import Agent, ActionGroup, Annotated, SenseMixin
@@ -155,7 +156,7 @@ async def main():
             )
             await agent.broadcast(agent.name, signal)
         except Exception:
-            pass
+            logging.getLogger(__name__).debug("PubNub broadcast failed", exc_info=True)
 
     try:
         while True:

--- a/examples/agent-sentinel/agents/scheduler.py
+++ b/examples/agent-sentinel/agents/scheduler.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import random
 import time
@@ -66,7 +67,7 @@ async def _publish_llm_event(agent: Scheduler, session_id: str, event) -> None:
             signal = Signal(kind="event", sender=agent.name, payload=payload)
             await agent.broadcast(agent.name, signal)
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("PubNub broadcast failed", exc_info=True)
 
 
 scheduler_tools = ActionGroup("scheduler_tools", "Calendar management tools")

--- a/examples/agent-sentinel/agents/sentinel_commander.py
+++ b/examples/agent-sentinel/agents/sentinel_commander.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import time
 
@@ -164,7 +165,7 @@ async def _publish_llm_event(agent: SentinelCommander, session_id: str, event) -
             signal = Signal(kind="event", sender=agent.name, payload=payload)
             await agent.broadcast(agent.name, signal)
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("PubNub broadcast failed", exc_info=True)
 
 
 async def main():

--- a/examples/agent-sentinel/agents/skill_acquirer.py
+++ b/examples/agent-sentinel/agents/skill_acquirer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import random
 import time
@@ -67,7 +68,7 @@ async def _publish_llm_event(agent: SkillAcquirer, session_id: str, event) -> No
             signal = Signal(kind="event", sender=agent.name, payload=payload)
             await agent.broadcast(agent.name, signal)
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("PubNub broadcast failed", exc_info=True)
 
 
 skill_tools = ActionGroup("skill_tools", "Skill installation tools")

--- a/examples/agent-sentinel/agents/supply_chain_sentinel.py
+++ b/examples/agent-sentinel/agents/supply_chain_sentinel.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import os
 
 from bedsheet import Agent, ActionGroup, Annotated, SenseMixin
@@ -202,7 +203,7 @@ async def main():
             )
             await agent.broadcast(agent.name, signal)
         except Exception:
-            pass
+            logging.getLogger(__name__).debug("PubNub broadcast failed", exc_info=True)
 
     try:
         while True:

--- a/examples/agent-sentinel/agents/web_researcher.py
+++ b/examples/agent-sentinel/agents/web_researcher.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import random
 import time
@@ -66,7 +67,7 @@ async def _publish_llm_event(agent: WebResearcher, session_id: str, event) -> No
             signal = Signal(kind="event", sender=agent.name, payload=payload)
             await agent.broadcast(agent.name, signal)
     except Exception:
-        pass  # Never kill the agent loop
+        logging.getLogger(__name__).debug("PubNub broadcast failed", exc_info=True)
 
 
 research_tools = ActionGroup("research_tools", "Web research tools")

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -844,3 +844,51 @@ async def test_enable_replay(tmp_path: Path):
     completions = [e for e in events if isinstance(e, CompletionEvent)]
     assert len(completions) == 1
     assert completions[0].response == "Replayed!"
+
+
+async def test_agent_invoke_handles_replay_exhaustion(tmp_path: Path):
+    """Agent.invoke() yields CompletionEvent without persisting to memory
+    when ReplayLLMClient is exhausted (stop_reason=replay_exhausted)."""
+    from bedsheet.recording import enable_replay
+    from bedsheet.agent import Agent
+    from bedsheet.events import ErrorEvent
+
+    path = tmp_path / "test.jsonl"
+    records = [
+        {
+            "type": "llm_call",
+            "seq": 0,
+            "agent": "test",
+            "messages_hash": "x",
+            "system_hash": "y",
+            "tools": [],
+        },
+        {
+            "type": "llm_response",
+            "seq": 0,
+            "text": "First response",
+            "tool_calls": [],
+            "stop_reason": "end_turn",
+            "thinking": None,
+            "parsed_output": None,
+        },
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+    agent = Agent(
+        name="test", instruction="Help.", model_client=MockLLMClient(responses=[])
+    )
+    enable_replay(agent, directory=str(tmp_path))
+
+    # First invoke consumes the one recorded response
+    events1 = [e async for e in agent.invoke("s1", "Hi")]
+    completions1 = [e for e in events1 if isinstance(e, CompletionEvent)]
+    assert completions1[0].response == "First response"
+
+    # Second invoke hits exhausted replay — should get CompletionEvent, not ErrorEvent
+    events2 = [e async for e in agent.invoke("s1", "Hi again")]
+    errors = [e for e in events2 if isinstance(e, ErrorEvent)]
+    assert len(errors) == 0
+    completions2 = [e for e in events2 if isinstance(e, CompletionEvent)]
+    assert len(completions2) == 1
+    assert "Replay ended" in completions2[0].response


### PR DESCRIPTION
## Summary

- **Supervisor replay_exhausted guard** -- Supervisor.invoke() overrides Agent.invoke() entirely, so the replay exhaustion fix from 8808cd8 did not apply. Supervisors would spin max_iterations times on exhausted recordings.
- **Supervisor empty-response guard** -- Adds the same text=None + tool_calls=[] bail-out that Agent already had for Gemini content-filtering.
- **PubNub error logging** -- Replaces bare except-pass in all 6 sentinel agent scripts with debug-level logging.
- **Integration test** -- Exercises full Agent.invoke() loop with exhausted ReplayLLMClient.

## Test plan

- [x] 373 passed, 1 pre-existing failure (test_memory_exports -- missing redis locally, passes in CI)
- [x] test_agent_invoke_handles_replay_exhaustion -- new integration test
- [x] All recording, agent, and supervisor tests pass